### PR TITLE
Updating nav bar to release 0.18.2

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -1,6 +1,6 @@
 <div class="header-banner">
-  <a href="https://github.com/flyteorg/flyte/releases/tag/v0.18.1" target="_blank">
-    Flyte 0.18.1 is out! 📣
+  <a href="https://github.com/flyteorg/flyte/releases/tag/v0.18.2" target="_blank">
+    Flyte 0.18.2 is out! 📣
   </a>
 </div>
 <nav


### PR DESCRIPTION
Updating the text and link of the top nav bar to announce Flyte release 0.18.2