### PR TITLE
update getting started link

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,7 +8,7 @@ plugins:
 
 #Links within the site
 documentation: "https://docs.flyte.org/"
-getstarted: "https://docs.flyte.org/en/latest/getting_started.html"
+getstarted: "https://docs.flyte.org/en/latest/getting_started/index.html"
 contribute: "https://docs.flyte.org/en/latest/community/contribute.html"
 learnmore: "https://docs.flyte.org/en/latest/index.html"
 email: "https://groups.google.com/d/forum/flyte-discuss"


### PR DESCRIPTION
Signed-off-by: Niels Bantilan <niels.bantilan@gmail.com>

The getting started link needs to be updated when https://github.com/flyteorg/flyte/pull/2037 is merged